### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/pr-dev.yml
+++ b/.github/workflows/pr-dev.yml
@@ -93,7 +93,7 @@ jobs:
         shell: bash
 
       - name: Build and Push Artefact to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BUILD_TYPE: ${{ env.BUILD_TYPE }}
         with:

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -91,7 +91,7 @@ jobs:
         shell: bash
 
       - name: Build and Push Artefact to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BUILD_TYPE: ${{ env.BUILD_TYPE }}
         with:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -91,7 +91,7 @@ jobs:
         shell: bash
 
       - name: Build and Push Artefact to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BUILD_TYPE: ${{ env.BUILD_TYPE }}
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore